### PR TITLE
Update prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nova-prettier",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/prettier.novaextension/Scripts/prettier.js
+++ b/prettier.novaextension/Scripts/prettier.js
@@ -8,7 +8,7 @@ module.exports = () => {
 			prettier: require('../node_modules/prettier/standalone.js'),
 			parsers: {
 				angularParser: require('../node_modules/prettier/parser-angular.js'),
-				babylonParser: require('../node_modules/prettier/parser-babylon.js'),
+				babelParser: require('../node_modules/prettier/parser-babel.js'),
 				flowParser: require('../node_modules/prettier/parser-flow.js'),
 				glimmerParser: require('../node_modules/prettier/parser-glimmer.js'),
 				graphqlParser: require('../node_modules/prettier/parser-graphql.js'),
@@ -16,7 +16,7 @@ module.exports = () => {
 				markdownParser: require('../node_modules/prettier/parser-markdown.js'),
 				postcssParser: require('../node_modules/prettier/parser-postcss.js'),
 				typescriptParser: require('../node_modules/prettier/parser-typescript.js'),
-				yamlParser: require('../node_modules/prettier/parser-yaml.js'),
+				yamlParser: require('../node_modules/prettier/parser-yaml.js')
 			}
 		};
 	}

--- a/prettier.novaextension/package-lock.json
+++ b/prettier.novaextension/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
     }
   }
 }

--- a/prettier.novaextension/package.json
+++ b/prettier.novaextension/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.5"
   }
 }

--- a/src/Scripts/prettier.js
+++ b/src/Scripts/prettier.js
@@ -6,7 +6,7 @@ module.exports = () => {
 			prettier: require('../node_modules/prettier/standalone.js'),
 			parsers: {
 				angularParser: require('../node_modules/prettier/parser-angular.js'),
-				babylonParser: require('../node_modules/prettier/parser-babylon.js'),
+				babelParser: require('../node_modules/prettier/parser-babel.js'),
 				flowParser: require('../node_modules/prettier/parser-flow.js'),
 				glimmerParser: require('../node_modules/prettier/parser-glimmer.js'),
 				graphqlParser: require('../node_modules/prettier/parser-graphql.js'),


### PR DESCRIPTION
Updated prettier to 2.0.5

I think it would be good to check if prettier exists locally in the users nova project, however i'm not able to `require` a module dynamically using rollup. Any ideas?