### PR TITLE
Only target the user-installed prettier lib

### DIFF
--- a/prettier.novaextension/Scripts/main.js
+++ b/prettier.novaextension/Scripts/main.js
@@ -165,7 +165,7 @@ async function checkPrettierVersion() {
 	});
 
 	const process = new Process('/usr/bin/env', {
-		args: ['npm', 'll', 'prettier', '--parseable'],
+		args: ['npm', 'll', 'prettier', '--parseable', '--depth', '0'],
 		cwd: nova.extension.path,
 	});
 

--- a/prettier.novaextension/Scripts/prettier.js
+++ b/prettier.novaextension/Scripts/prettier.js
@@ -17,7 +17,7 @@ async function findPrettier() {
 	});
 
 	const process = new Process('/usr/bin/env', {
-		args: ['npm', 'll', 'prettier', '--parseable'],
+		args: ['npm', 'll', 'prettier', '--parseable', '--depth', '0'],
 		cwd: nova.workspace.path,
 	});
 

--- a/src/Scripts/install.js
+++ b/src/Scripts/install.js
@@ -9,7 +9,7 @@ async function checkPrettierVersion() {
 	})
 
 	const process = new Process('/usr/bin/env', {
-		args: ['npm', 'll', 'prettier', '--parseable'],
+		args: ['npm', 'll', 'prettier', '--parseable', '--depth', '0'],
 		cwd: nova.extension.path,
 	})
 

--- a/src/Scripts/prettier.js
+++ b/src/Scripts/prettier.js
@@ -15,7 +15,7 @@ async function findPrettier() {
 	})
 
 	const process = new Process('/usr/bin/env', {
-		args: ['npm', 'll', 'prettier', '--parseable'],
+		args: ['npm', 'll', 'prettier', '--parseable', '--depth', '0'],
 		cwd: nova.workspace.path,
 	})
 


### PR DESCRIPTION
Right now it's possible that this extension will automatically find a version of prettier in node_modules that is not the intended one by the user. For instance, in my situation, when I ran:

`npm ll prettier --parseable`

I got: 

`/Users/myuser/my-project/node_modules/@vue/component-compiler-utils/node_modules/prettier:prettier@1.19.1:undefined`
`/Users/myuser/my-project/node_modules/prettier:prettier@2.1.2:undefined`

The first result is a dependency of a dependency, and it is the unintended version. So I changed the lookup command to:

`npm ll prettier --parseable --depth 1`

Sure enough I only get the one result, and that is the correct result:

`/Users/myuser/my-project/node_modules/prettier:prettier@2.1.2:undefined`
